### PR TITLE
find-python.js add prevalidate python version check

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -282,7 +282,8 @@ class PythonFinder {
           )
         },
         checkFunc: this.checkPyLauncher,
-        name: 'py Launcher'
+        name: 'py Launcher',
+        arg: this.pyLauncher
       })
     }
 
@@ -296,7 +297,7 @@ class PythonFinder {
    * @type {object}
    * @property {(name: string) => number|void} [before] what to execute before running check itself
    * @property {function} checkFunc function which will perform check
-   * @property {string} [arg] what will be executed
+   * @property {string} arg what will be executed
    * @property {string} [name] how check is named. this name is displayed to user
    * @property {{shell: boolean}} [options] additional data, may be extended later, if shell true, exec command as in shell
    */
@@ -340,6 +341,9 @@ class PythonFinder {
             check.arg || check.name
           )}" to get Python executable path`
         )
+
+        // TODO: trust to prevalidate (when prevalidate fail check fail) and add option to disable prevalidates
+        await this.prevalidatePythonVersion(check.arg, this.win)
 
         const result = await check.checkFunc.apply(this, [
           check ? check.arg : null
@@ -396,6 +400,7 @@ class PythonFinder {
    * being in the $PATH.
    *
    * @private
+   * @argument {string} pyLauncher path to pyLauncher
    * @returns {Promise}
    */
   // theoretically this method can be removed in favor of checkCommand and getChecks.
@@ -411,9 +416,9 @@ class PythonFinder {
   // Passing check to every function from previous in promise chain would lead to
   // hard to fix errors and overcomplicate structure of module
 
-  checkPyLauncher () {
+  checkPyLauncher (pyLauncher) {
     return new Promise((resolve, reject) => {
-      this.run(this.pyLauncher, this.argsExecutable, false)
+      this.run(pyLauncher, this.argsExecutable, false)
         .then(this.checkExecPath)
         .then(resolve)
         .catch(reject)
@@ -465,6 +470,61 @@ class PythonFinder {
         })
         .catch(reject)
     })
+  }
+
+  /**
+   * @private
+   * @param {string} exec what try to execute with "--version"
+   * @param {boolean} [shell] either use shell mode or not
+   * @returns
+   */
+  async prevalidatePythonVersion (exec, shell) {
+    const failMessage = 'Prevalidate fail'
+
+    this.logger.addLog('Prevalidate python version')
+
+    let versionOutput = ''
+
+    try {
+      versionOutput = await this.run(shell && this.win ? `"${exec}"` : exec, ['--version'], shell)
+    } catch (err) {
+      // "run" treats any data in stderr as error and pass it in err.data.stderr
+      // thus if we have no actual error, get input from stderr
+      if (err.data && !err.error) {
+        versionOutput = err.data.stderr
+      } else {
+        // if any actual error just fail
+        // it is just prevalidate thats why user not interested why it is failed
+        this.logger.addLog(failMessage)
+        return
+      }
+    }
+
+    this.logger.log.silly(`${this.logger.colorizeOutput(Logger.colors.GREEN, 'versionOutput:')} ${versionOutput}`)
+
+    // semver.coerce return null if can't parse
+    const versionObj = semver.coerce(versionOutput)
+    if (!versionObj) {
+      (new PythonVersionError(null, 'Can not parse version')).log(this.logger)
+      this.logger.addLog(failMessage)
+    } else {
+      // if parse succeed
+      this.logger.addLog(`${this.logger.colorizeOutput(Logger.colors.GREEN, 'Version parsed')}: ${versionObj.version}`)
+      this.logger.log.silly(this.logger.colorizeOutput(Logger.colors.GREEN, 'versionObj'), versionObj)
+
+      // include('python') needed to make sure is it a python at all
+      if (!semver.satisfies(versionObj, this.semverRange) && versionOutput.toLowerCase().includes('python')) {
+        (new PythonVersionError({ received: versionObj.version, wanted: this.semverRange },
+          `Found unsupported Python version ${versionObj.version}`)).log(this.logger)
+
+        this.logger.addLog(failMessage)
+        this.logger.addLog('Below can be weird error due to unsupported python version')
+        return
+      }
+
+      // mean that we guessed and it is really python executable with supported version
+      this.logger.addLog('Prevalidate pass')
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

It happens that sometimes little python script which should return path to python executable is running on unsupported python version. In such situations strange and frightening errors occure 👻. So user can be missleaded. This PR adds simple prevalidation (via `ptyhon -V` command which should return version). That prevalidation verify that we having deal with supported python and if not warn the user that below can be weird error due to unsupported python version. This change can minimize new issues will be open here on github with tipical errors and also improve user experience.


